### PR TITLE
Add setup script for Codex

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+# Install dotnet SDK if not already installed
+if ! command -v dotnet >/dev/null 2>&1; then
+    echo "Installing .NET SDK..."
+    # Add Microsoft package signing key and repository
+    wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    rm packages-microsoft-prod.deb
+    sudo apt-get update
+    sudo apt-get install -y dotnet-sdk-8.0
+fi
+
+# Restore NuGet packages
+if [ -f "FaerieTables/FaerieTables.sln" ]; then
+    dotnet restore FaerieTables/FaerieTables.sln
+else
+    dotnet restore
+fi


### PR DESCRIPTION
## Summary
- add a setup script that installs the .NET 8 SDK and restores NuGet packages

## Testing
- `./setup.sh`
- `dotnet test FaerieTables/FaerieTables.Api.Tests/FaerieTables.Api.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9e31f9e8832c84b1a95be09605ed