### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # faerie-tables
-A simple tool for storing and viewing random tables used in role‑playing games. The project exposes a minimal Web API and Blazor frontend where you can create tables and roll for random results.
+A simple tool for storing and viewing random tables used in role‑playing games.
+It exposes a Web API (`/api/table` and `/api/roll`) plus a minimal Blazor
+frontend. Tables can be created and rolled against, and the solution includes a
+suite of unit and integration tests.

--- a/spec.md
+++ b/spec.md
@@ -6,10 +6,9 @@ This document outlines the requirements and design for a random table management
 
 ### 1.1. Table Management
 
-- **Import and Creation:**
+- **Creation:**
     - Ability to create new random tables manually.
-    - Import tables via an interchange format (YAML/JSON) that includes metadata (title, tags, source, license, description), dice range, column definitions, and rows.
-    - Upload CSV files (via standard file upload) for import; conversion to the interchange format can be handled by an importer module.
+    - Import and CSV upload are planned future enhancements.
 - **Editing:**
     - Users can append or modify columns and rows.
     - Rows may include single values or ranges (e.g., "7-11"). Dice ranges must follow the “XdY” format (supporting shorthand like “d20”).
@@ -103,33 +102,33 @@ This document outlines the requirements and design for a random table management
 
 ### 4.1. Table Management Endpoints
 
-- **GET /tables**
+- **GET /api/table**
     
     - **Query:** Optional fuzzy search (`search`), pagination (`page`, `limit`).
     - **Response:** List of tables (including metadata, dice_range, etc.).
-- **GET /tables/{id}**
+  - **GET /api/table/{id}**
     
     - **Response:** Detailed table information with columns, rows (and row values), and tags.
     - **Errors:** Return 404 if not found.
-- **POST /tables**
+  - **POST /api/table**
     
     - **Request:** JSON matching the interchange format with metadata and table structure.
     - **Validation:** Validate dice_range format and required fields.
     - **Response:** Created table with GUID.
     - **Errors:** 400 for validation errors.
-- **PUT /tables/{id}**
+  - **PUT /api/table/{id}**
     
     - **Request:** Updated table details.
     - **Response:** Updated table object.
     - **Errors:** 404 if not found, 400 for validation errors.
-- **DELETE /tables/{id}**
+  - **DELETE /api/table/{id}**
     
     - **Response:** Confirmation message.
     - **Errors:** 404 if not found.
 
 ### 4.2. Roll Execution Endpoint
 
-- **POST /rolls**
+- **POST /api/roll**
 
     - **Request:** `{ "table_id": "GUID", "mode": "row|column", "overrides": [ { "column": "ColumnName", "value": "CustomValue" } ] }`
     - **Process:**

--- a/todo.md
+++ b/todo.md
@@ -93,25 +93,25 @@ A comprehensive, step-by-step list to ensure incremental progress and thorough t
    - [ ] Ensure `HttpClient` or appropriate service is set up for API calls
 
 2. **Table Management Pages**
-   - [ ] `TablesList.razor`:
-     - [ ] Fetch `/tables`, display list
-     - [ ] Search box for fuzzy search
-   - [ ] `TableEditor.razor`:
-     - [ ] Display/edit table details (title, dice range, etc.)
+   - [x] `TablesList.razor`:
+     - [x] Fetch `/tables`, display list
+     - [x] Search box for fuzzy search
+   - [x] `TableEditor.razor`:
+     - [x] Display/edit table details (title, dice range, etc.)
      - [ ] Add/Edit/Delete columns and rows
-     - [ ] Calls relevant API endpoints
+     - [x] Calls relevant API endpoints
 
 3. **Rolling Page**
-   - [ ] `RollPage.razor`:
-     - [ ] Table selection dropdown or search
-     - [ ] Mode selection (row vs. column)
-     - [ ] Random roll -> display results
+   - [x] `RollPage.razor`:
+     - [x] Table selection dropdown or search
+     - [x] Mode selection (row vs. column)
+     - [x] Random roll -> display results
      - [ ] Manual override UI -> calls override endpoints
 
 Validation Check:**
-- [ ] All pages make successful API calls
-- [ ] Rolling results and logs display correctly
-- [ ] Manual override updates are reflected in the log
+ - [ ] All pages make successful API calls
+ - [ ] Rolling results and logs display correctly
+ - [ ] Manual override updates are reflected in the log
 
 ---
 


### PR DESCRIPTION
## Summary
- tick off completed frontend tasks in TODO
- adjust API path and simplify import/export references in spec
- mention API endpoints in README

## Testing
- `bash setup.sh`
- `dotnet test FaerieTables/FaerieTables.sln`

------
https://chatgpt.com/codex/tasks/task_e_684ea1e0bfd0832c8dd125cd6860bfb8