### PR TITLE
Enable Swagger across environments

### DIFF
--- a/FaerieTables/FaerieTables.Api/Controllers/HelloController.cs
+++ b/FaerieTables/FaerieTables.Api/Controllers/HelloController.cs
@@ -2,6 +2,9 @@
 
 namespace FaerieTables.Api.Controllers;
 
+/// <summary>
+/// Provides a simple greeting endpoint.
+/// </summary>
 [ApiController]
 [Route("api/[controller]")]
 public class HelloController : ControllerBase

--- a/FaerieTables/FaerieTables.Api/Controllers/RollController.cs
+++ b/FaerieTables/FaerieTables.Api/Controllers/RollController.cs
@@ -6,6 +6,9 @@ using System.Linq;
 
 namespace FaerieTables.Api.Controllers
 {
+    /// <summary>
+    /// Rolls against stored tables and returns the results.
+    /// </summary>
     [ApiController]
     [Route("api/[controller]")]
     public class RollController : ControllerBase

--- a/FaerieTables/FaerieTables.Api/Controllers/TableController.cs
+++ b/FaerieTables/FaerieTables.Api/Controllers/TableController.cs
@@ -5,6 +5,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace FaerieTables.Api.Controllers;
 
+/// <summary>
+/// Manages CRUD operations for random tables.
+/// </summary>
 [ApiController]
 [Route("api/[controller]")]
 public class TableController(ITableService tableService) : ControllerBase

--- a/FaerieTables/FaerieTables.Api/Program.cs
+++ b/FaerieTables/FaerieTables.Api/Program.cs
@@ -22,10 +22,11 @@ var app = builder.Build();
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
     app.UseDeveloperExceptionPage();
 }
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseHttpsRedirection();
 app.MapControllers();


### PR DESCRIPTION
## Summary
- document API controllers
- enable Swagger middleware in all environments

## Testing
- `bash setup.sh`
- `dotnet test FaerieTables.Api.Tests/FaerieTables.Api.Tests.csproj -v diag`

------
https://chatgpt.com/codex/tasks/task_e_684eaf8c0e9c832cb90b2133f2b3fd03